### PR TITLE
Fix "ignore" code

### DIFF
--- a/syslog-summary
+++ b/syslog-summary
@@ -198,6 +198,7 @@ def summarize(filename, states):
 			if DEBUG:
 				print "Ignoring: %s" % line
 			line = file.readline()
+			continue
 		
 		date, rest = split_date(line)
 		if date:


### PR DESCRIPTION
Bug Fix: If there are two consecutive lines which should be ignored, the second would not be.  In other words, the line after an ignored line is always included.
